### PR TITLE
feat[]: use nvm on loading

### DIFF
--- a/zsh-nvm-auto-switch.plugin.zsh
+++ b/zsh-nvm-auto-switch.plugin.zsh
@@ -21,3 +21,4 @@ function nvm_auto_switch {
 
 autoload -U add-zsh-hook
 add-zsh-hook chpwd nvm_auto_switch
+nvm_auto_switch


### PR DESCRIPTION
Automatically use nvm when terminal opened.

It avoid using `cd` while opening our IDE.

![Kapture 2022-08-19 at 10 29 01](https://user-images.githubusercontent.com/7447983/185578118-a392af04-bc9a-4d67-8d63-d95428969358.gif)
